### PR TITLE
Relax omniauth-oauth2 dep requirement

### DIFF
--- a/omniauth-zoom.gemspec
+++ b/omniauth-zoom.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'omniauth', '~> 2.0'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codecov'


### PR DESCRIPTION
## Summary

The current dependency requirements are too strict to support up-to-date versions of other oauth2 strategy gems. Most notably [`omniauth-google-oauth2`](https://github.com/zquestz/omniauth-google-oauth2) which requires version `~> 1.8`  of `omniauth-oauth2` (`gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8'`)